### PR TITLE
ci: set a predictable temp output path for `vgret` with `VTMP`

### DIFF
--- a/.github/workflows/doom_gfx_regressions.yml
+++ b/.github/workflows/doom_gfx_regressions.yml
@@ -19,6 +19,7 @@ jobs:
       VFLAGS: -cc tcc
       DISPLAY: :99
       LIBGL_ALWAYS_SOFTWARE: true
+      VTMP: /tmp
     steps:
       - name: Checkout V
         uses: actions/checkout@v2


### PR DESCRIPTION
Set `VTMP` env var to let `vgret` output any fail images to a predictable path.
It is already done so in V's CI https://github.com/vlang/v/blob/13fd5493d34b45751a31ea0ff5119a1e064310c5/.github/workflows/gg_regressions_ci.yml#L20